### PR TITLE
Using brpop instead of rpop to block for incoming jobs

### DIFF
--- a/baobab/actionrunner/actionrunner.v
+++ b/baobab/actionrunner/actionrunner.v
@@ -48,6 +48,9 @@ pub fn (mut ar ActionRunner) run() {
 			eprintln('Expected 2 items in result of brpop!')
 			continue
 		}
+		if res[1] == "" {
+			continue
+		}
 		mut job := ar.client.job_get(res[1]) or {
 			eprintln('Failed getting job from db: ${err}')
 			continue

--- a/baobab/actionrunner/actionrunner.v
+++ b/baobab/actionrunner/actionrunner.v
@@ -37,15 +37,9 @@ pub fn (mut ar ActionRunner) run() {
 		}
 		// pull jobs for our actors: first one in the queues of our actors will be executed continue after 
 		res := ar.client.redis.brpop(queues_actors, 1) or {
-			eprintln('Failed checking job process: ${err}')
-			continue
-		}
-		if res.len == 0 {
-			// no jobs in queues
-			continue
-		}
-		if res.len != 2 {
-			eprintln('Expected 2 items in result of brpop!')
+			if "$err" != "timeout on brpop" {
+				eprintln("Unexpected error: $err")
+			}
 			continue
 		}
 		if res[1] == "" {

--- a/baobab/actionrunner/actionrunner.v
+++ b/baobab/actionrunner/actionrunner.v
@@ -3,7 +3,6 @@ module actionrunner
 import freeflowuniverse.baobab.actor
 import freeflowuniverse.baobab.client { Client }
 import freeflowuniverse.baobab.jobs { ActionJob }
-
 import rand
 
 // Actionrunner listens to jobs in an actors queue
@@ -20,7 +19,7 @@ pub mut:
 
 // factory function for actionrunner
 pub fn new(client_ Client, actors []&actor.IActor) ActionRunner {
-	mut ar := ActionRunner {
+	mut ar := ActionRunner{
 		actors: actors
 		client: &client_
 	}
@@ -32,17 +31,15 @@ pub fn (mut ar ActionRunner) run() {
 	mut queues_actors := ar.actors.map('jobs.actors.${it.name}')
 	// go over jobs.actors in redis, see which jobs we have pass them onto the execute
 	for ar.running {
-		rand.shuffle[string](mut queues_actors) or {
-			eprintln("Failed to shuffle actor queues")
-		}
-		// pull jobs for our actors: first one in the queues of our actors will be executed continue after 
+		rand.shuffle[string](mut queues_actors) or { eprintln('Failed to shuffle actor queues') }
+		// pull jobs for our actors: first one in the queues of our actors will be executed continue after
 		res := ar.client.redis.brpop(queues_actors, 1) or {
-			if "$err" != "timeout on brpop" {
-				eprintln("Unexpected error: $err")
+			if '${err}' != 'timeout on brpop' {
+				eprintln('Unexpected error: ${err}')
 			}
 			continue
 		}
-		if res.len != 2 || res[1] == "" {
+		if res.len != 2 || res[1] == '' {
 			continue
 		}
 		mut job := ar.client.job_get(res[1]) or {

--- a/baobab/actionrunner/actionrunner.v
+++ b/baobab/actionrunner/actionrunner.v
@@ -3,12 +3,14 @@ module actionrunner
 import freeflowuniverse.baobab.actor
 import freeflowuniverse.baobab.client { Client }
 import freeflowuniverse.baobab.jobs { ActionJob }
-import time
+
+import rand
 
 // Actionrunner listens to jobs in an actors queue
 // executes the jobs internally
 // sets the status of the job in jobs.db in the process
 // then moves jobs into processor.error/result queues
+[heap]
 pub struct ActionRunner {
 pub mut:
 	actors  []&actor.IActor
@@ -18,7 +20,7 @@ pub mut:
 
 // factory function for actionrunner
 pub fn new(client_ Client, actors []&actor.IActor) ActionRunner {
-	mut ar := ActionRunner{
+	mut ar := ActionRunner {
 		actors: actors
 		client: &client_
 	}
@@ -27,27 +29,30 @@ pub fn new(client_ Client, actors []&actor.IActor) ActionRunner {
 
 pub fn (mut ar ActionRunner) run() {
 	ar.running = true
+	mut queues_actors := ar.actors.map('jobs.actors.${it.name}')
 	// go over jobs.actors in redis, see which jobs we have pass them onto the execute
 	for ar.running {
-		// do for each actor
-		for actor in ar.actors {
-			// get guid in queue, move on if nil
-			job_guid := ar.client.check_job_process(actor.name, 0) or {
-				eprintln('Failed checking job process: ${err}')
-				continue
-			}
-			if job_guid == '' {
-				continue
-			}
-
-			// get job, set job active and execute
-			mut job := ar.client.job_get(job_guid) or {
-				eprintln('Failed getting job from db: ${err}')
-				continue
-			}
-			ar.execute(mut job) or { eprintln('Failed to execute the job: ${err}') }
+		rand.shuffle[string](mut queues_actors) or {
+			eprintln("Failed to shuffle actor queues")
 		}
-		time.sleep(100 * time.millisecond)
+		// pull jobs for our actors: first one in the queues of our actors will be executed continue after 
+		res := ar.client.redis.brpop(queues_actors, 1) or {
+			eprintln('Failed checking job process: ${err}')
+			continue
+		}
+		if res.len == 0 {
+			// no jobs in queues
+			continue
+		}
+		if res.len != 2 {
+			eprintln('Expected 2 items in result of brpop!')
+			continue
+		}
+		mut job := ar.client.job_get(res[1]) or {
+			eprintln('Failed getting job from db: ${err}')
+			continue
+		}
+		ar.execute(mut job) or { eprintln('Failed to execute the job: ${err}') }
 	}
 }
 

--- a/baobab/actionrunner/actionrunner.v
+++ b/baobab/actionrunner/actionrunner.v
@@ -42,7 +42,7 @@ pub fn (mut ar ActionRunner) run() {
 			}
 			continue
 		}
-		if res[1] == "" {
+		if res.len != 2 || res[1] == "" {
 			continue
 		}
 		mut job := ar.client.job_get(res[1]) or {

--- a/baobab/actionrunner/actionrunner_test.v
+++ b/baobab/actionrunner/actionrunner_test.v
@@ -42,7 +42,7 @@ fn mock_processor(action string, add_to_db bool) ! {
 	mut q_actor := redis.queue_get(q_key)
 	q_actor.add(job.guid)!
 
-	time.sleep(5000000000)
+	time.sleep(500000)
 
 	// check error and result queues to see if any guids were returned
 	mut q_error := redis.queue_get('jobs.processor.error')

--- a/baobab/actionrunner/actionrunner_test.v
+++ b/baobab/actionrunner/actionrunner_test.v
@@ -42,7 +42,7 @@ fn mock_processor(action string, add_to_db bool) ! {
 	mut q_actor := redis.queue_get(q_key)
 	q_actor.add(job.guid)!
 
-	time.sleep(500000000)
+	time.sleep(5000000000)
 
 	// check error and result queues to see if any guids were returned
 	mut q_error := redis.queue_get('jobs.processor.error')

--- a/baobab/actionrunner/actionrunner_test.v
+++ b/baobab/actionrunner/actionrunner_test.v
@@ -45,10 +45,10 @@ fn mock_processor(action string, add_to_db bool) ! {
 	time.sleep(500000)
 
 	// check error and result queues to see if any guids were returned
-	mut q_error := redis.queue_get('jobs.processor.error')
-	mut q_result := redis.queue_get('jobs.processor.result')
-	guid_error := q_error.pop() or { '' }
-	guid_result := q_result.pop() or { '' }
+	res := redis.brpop(['jobs.processor.result'], 60)!
+	assert res.len == 2
+	guid_result := res[1]
+	guid_error := redis.rpop('jobs.processor.error') or { '' }
 
 	assert guid_error == ''
 	assert guid_result == job.guid

--- a/baobab/client/client.v
+++ b/baobab/client/client.v
@@ -82,7 +82,7 @@ pub fn (mut client Client) job_wait(guid string, timeout_ int) !ActionJob {
 		timeout = 3600
 	}
 	key := 'jobs.return.${guid}'
-	client.redis.brpop(key, timeout)! // will block and wait
+	client.redis.brpop([key], timeout)! // will block and wait
 	return client.job_get(guid)!
 }
 

--- a/baobab/client/jobs_process.v
+++ b/baobab/client/jobs_process.v
@@ -17,7 +17,8 @@ fn action_get_key(action_ string) !string {
 pub fn (mut client Client) check_job_process(action string, timeout int) !string {
 	key := action_get_key(action)!
 	if timeout > 0 {
-		return client.redis.brpop(key, timeout)!
+		res := client.redis.brpop([key], timeout)!
+		return res[1]
 	} else {
 		return client.redis.rpop(key)!
 	}

--- a/baobab/processor/processor.v
+++ b/baobab/processor/processor.v
@@ -40,9 +40,12 @@ pub fn (mut p Processor) run() {
 		if res.len == 0 {
 			// no guids to handle
 			continue
-		}		
+		}
 		if res.len != 2 {
 			p.logger.error('Expected 2 items in result of brpop!')
+			continue
+		}
+		if res[1] == "" {
 			continue
 		}
 		match res[0] {

--- a/baobab/processor/processor.v
+++ b/baobab/processor/processor.v
@@ -8,16 +8,18 @@ import time
 [noinit]
 pub struct Processor {
 mut:
-	client client.Client
+	//client client.Client
 	errors []IError
 	logger &log.Logger
 pub mut:
 	running bool
+	redis_address string
 }
 
 pub fn new(redis_address string, logger &log.Logger) !Processor {
 	return Processor{
-		client: client.new(redis_address)!
+		redis_address: redis_address
+		//client: client.new(redis_address)!
 		logger: unsafe { logger }
 	}
 }
@@ -26,47 +28,78 @@ pub fn new(redis_address string, logger &log.Logger) !Processor {
 // returns error and result responses from actor to caller of job
 pub fn (mut p Processor) run() {
 	p.logger.info('Processor is running')
-
-	mut q_rmb := p.client.redis.queue_get('msgbus.execute_job')
-	mut q_in := p.client.redis.queue_get('jobs.processor.in')
-	mut q_error := p.client.redis.queue_get('jobs.processor.error')
-	mut q_result := p.client.redis.queue_get('jobs.processor.result')
-
 	p.running = true
+
+	t1 := spawn p.handle_in()
+	t2 := spawn p.handle_rmb()
+	t3 := spawn p.handle_errors()
+	t4 := spawn p.handle_results()
+
+	t1.wait()
+	t2.wait()
+	t3.wait()
+	t4.wait()
+}
+
+fn (mut p Processor) handle_in() {
+	mut client_ := client.new(p.redis_address) or {
+		return
+	}
 	for p.running {
 		// get guid from processor.in queue and assign job to actor
-		guid_in := q_in.pop() or { '' }
+		guid_in := client_.redis.brpop('jobs.processor.in', 1) or { '' }
 		if guid_in != '' {
 			p.logger.debug('Received job ${guid_in}')
-			p.assign_job(guid_in) or { p.handle_error(err) }
+			p.assign_job(mut client_, guid_in) or { p.handle_error(mut client_, err) }
 		}
+	}
+}
 
+fn (mut p Processor) handle_rmb(){
+	mut client_ := client.new(p.redis_address) or {
+		return
+	}
+	for p.running {
 		// get msg from rmb queue, parse job, assign to actor
-		if guid_rmb := p.get_rmb_job(mut q_rmb) {
+		if guid_rmb := p.get_rmb_job(mut client_) {
 			p.logger.debug('Received job ${guid_rmb} from RMB')
-			p.assign_job(guid_rmb) or { p.handle_error(err) }
+			p.assign_job(mut client_, guid_rmb) or { p.handle_error(mut client_, err) }
 		}
+	}
+}
 
+fn (mut p Processor) handle_errors() {
+	mut client_ := client.new(p.redis_address) or {
+		return
+	}
+	for p.running {
 		// get guid from processor.error queue and move to return queue
-		guid_error := q_error.pop() or { '' }
+		guid_error := client_.redis.brpop('jobs.processor.error', 1) or { '' }
 		if guid_error != '' {
 			p.logger.debug('Received error response for job: ${guid_error} ')
-			p.return_job(guid_error) or { p.handle_error(err) }
+			p.return_job(mut client_, guid_error) or { p.handle_error(mut client_, err) }
 		}
+	}
+}
 
+fn (mut p Processor) handle_results(){
+	mut client_ := client.new(p.redis_address) or {
+		return
+	}
+	for p.running {
 		// get guid from processor.result queue and move to return queue
-		guid_result := q_result.pop() or { '' }
+		guid_result := client_.redis.brpop('jobs.processor.result', 1) or { '' }
 		if guid_result != '' {
 			p.logger.debug('Received result for job: ${guid_result}')
-			p.return_job(guid_result) or { p.handle_error(err) }
+			p.return_job(mut client_, guid_result) or { p.handle_error(mut client_, err) }
 		}
-		time.sleep(100 * time.millisecond)
+		//time.sleep(100 * time.millisecond)
 	}
 }
 
 // assign_job places guid to correct actor queue, and to the processor.active queue
-fn (mut p Processor) assign_job(guid string) ! {
-	mut job := p.client.job_get(guid)!
+fn (mut p Processor) assign_job(mut client_ client.Client, guid string) ! {
+	mut job := client_.job_get(guid)!
 
 	if !job.check_timeout_ok() {
 		return jobs.JobError{
@@ -76,12 +109,12 @@ fn (mut p Processor) assign_job(guid string) ! {
 	}
 
 	// push guid to active queue
-	mut q_active := p.client.redis.queue_get('jobs.processor.active')
+	mut q_active := client_.redis.queue_get('jobs.processor.active')
 	q_active.add(guid)!
 
 	// push guid to queue of actor which will handle job
 	q_key := 'jobs.actors.${job.action.all_before_last('.')}'
-	mut q_actor := p.client.redis.queue_get(q_key)
+	mut q_actor := client_.redis.queue_get(q_key)
 	q_actor.add(guid)!
 
 	p.logger.debug('Assigned job ${guid} to ${q_key}:')
@@ -89,28 +122,28 @@ fn (mut p Processor) assign_job(guid string) ! {
 }
 
 // return_job returns a job by placing it to the correct redis return queue
-fn (mut p Processor) return_job(guid string) ! {
-	if p.client.redis.hexists('rmb.db', guid)! {
-		p.return_job_rmb(guid)!
+fn (mut p Processor) return_job(mut client_ client.Client, guid string) ! {
+	if client_.redis.hexists('rmb.db', guid)! {
+		p.return_job_rmb(mut client_, guid)!
 	} else {
-		mut q_return := p.client.redis.queue_get('jobs.return.${guid}')
+		mut q_return := client_.redis.queue_get('jobs.return.${guid}')
 		q_return.add(guid)!
 	}
 	p.logger.debug('Returned job ${guid}')
 }
 
 // handle_error places guid to jobs.return queue with an error
-fn (mut p Processor) handle_error(error IError) {
+fn (mut p Processor) handle_error(mut client_ client.Client, error IError) {
 	if error is jobs.JobError {
-		mut job := p.client.job_get(error.job_guid) or {
+		mut job := client_.job_get(error.job_guid) or {
 			eprintln('Failed getting the job with id ${error.job_guid}: ${err}')
 			return
 		}
-		p.client.job_error_set(mut job, error.msg) or {
+		client_.job_error_set(mut job, error.msg) or {
 			eprintln('Failed modifying the status of the job ${error.job_guid} to error: ${err}')
 			return
 		}
-		p.return_job(error.job_guid) or {
+		p.return_job(mut client_, error.job_guid) or {
 			eprintln('Failed returning the job ${error.job_guid}: ${err}')
 			return
 		}
@@ -120,16 +153,19 @@ fn (mut p Processor) handle_error(error IError) {
 }
 
 pub fn (mut p Processor) reset() ! {
-	p.client.redis.flushall()!
-	p.client.redis.disconnect()
-	p.client.redis.socket_connect()!
+	mut client_ := client.new(p.redis_address) or {
+		return
+	}
+	client_.redis.flushall()!
+	client_.redis.disconnect()
+	client_.redis.socket_connect()!
 }
 
 // todo: fix if needed
 // fn (mut p Processor) restart()! {
-// 	p.client.redis.save()!
-// 	p.client.redis.shutdown()!
+// 	client_.redis.save()!
+// 	client_.redis.shutdown()!
 // 	// os.execute('redis-server --daemonize yes &')
 // 	time.sleep(1000000)
-// 	p.client.redis.socket_connect()!
+// 	client_.redis.socket_connect()!
 // }

--- a/baobab/processor/processor.v
+++ b/baobab/processor/processor.v
@@ -8,18 +8,16 @@ import time
 [noinit]
 pub struct Processor {
 mut:
-	//client client.Client
+	client client.Client
 	errors []IError
 	logger &log.Logger
 pub mut:
 	running bool
-	redis_address string
 }
 
 pub fn new(redis_address string, logger &log.Logger) !Processor {
 	return Processor{
-		redis_address: redis_address
-		//client: client.new(redis_address)!
+		client: client.new(redis_address)!
 		logger: unsafe { logger }
 	}
 }
@@ -28,78 +26,47 @@ pub fn new(redis_address string, logger &log.Logger) !Processor {
 // returns error and result responses from actor to caller of job
 pub fn (mut p Processor) run() {
 	p.logger.info('Processor is running')
+
+	mut q_rmb := p.client.redis.queue_get('msgbus.execute_job')
+	mut q_in := p.client.redis.queue_get('jobs.processor.in')
+	mut q_error := p.client.redis.queue_get('jobs.processor.error')
+	mut q_result := p.client.redis.queue_get('jobs.processor.result')
+
 	p.running = true
-
-	t1 := spawn p.handle_in()
-	t2 := spawn p.handle_rmb()
-	t3 := spawn p.handle_errors()
-	t4 := spawn p.handle_results()
-
-	t1.wait()
-	t2.wait()
-	t3.wait()
-	t4.wait()
-}
-
-fn (mut p Processor) handle_in() {
-	mut client_ := client.new(p.redis_address) or {
-		return
-	}
 	for p.running {
 		// get guid from processor.in queue and assign job to actor
-		guid_in := client_.redis.brpop('jobs.processor.in', 1) or { '' }
+		guid_in := q_in.pop() or { '' }
 		if guid_in != '' {
 			p.logger.debug('Received job ${guid_in}')
-			p.assign_job(mut client_, guid_in) or { p.handle_error(mut client_, err) }
+			p.assign_job(guid_in) or { p.handle_error(err) }
 		}
-	}
-}
 
-fn (mut p Processor) handle_rmb(){
-	mut client_ := client.new(p.redis_address) or {
-		return
-	}
-	for p.running {
 		// get msg from rmb queue, parse job, assign to actor
-		if guid_rmb := p.get_rmb_job(mut client_) {
+		if guid_rmb := p.get_rmb_job(mut q_rmb) {
 			p.logger.debug('Received job ${guid_rmb} from RMB')
-			p.assign_job(mut client_, guid_rmb) or { p.handle_error(mut client_, err) }
+			p.assign_job(guid_rmb) or { p.handle_error(err) }
 		}
-	}
-}
 
-fn (mut p Processor) handle_errors() {
-	mut client_ := client.new(p.redis_address) or {
-		return
-	}
-	for p.running {
 		// get guid from processor.error queue and move to return queue
-		guid_error := client_.redis.brpop('jobs.processor.error', 1) or { '' }
+		guid_error := q_error.pop() or { '' }
 		if guid_error != '' {
 			p.logger.debug('Received error response for job: ${guid_error} ')
-			p.return_job(mut client_, guid_error) or { p.handle_error(mut client_, err) }
+			p.return_job(guid_error) or { p.handle_error(err) }
 		}
-	}
-}
 
-fn (mut p Processor) handle_results(){
-	mut client_ := client.new(p.redis_address) or {
-		return
-	}
-	for p.running {
 		// get guid from processor.result queue and move to return queue
-		guid_result := client_.redis.brpop('jobs.processor.result', 1) or { '' }
+		guid_result := q_result.pop() or { '' }
 		if guid_result != '' {
 			p.logger.debug('Received result for job: ${guid_result}')
-			p.return_job(mut client_, guid_result) or { p.handle_error(mut client_, err) }
+			p.return_job(guid_result) or { p.handle_error(err) }
 		}
-		//time.sleep(100 * time.millisecond)
+		time.sleep(100 * time.millisecond)
 	}
 }
 
 // assign_job places guid to correct actor queue, and to the processor.active queue
-fn (mut p Processor) assign_job(mut client_ client.Client, guid string) ! {
-	mut job := client_.job_get(guid)!
+fn (mut p Processor) assign_job(guid string) ! {
+	mut job := p.client.job_get(guid)!
 
 	if !job.check_timeout_ok() {
 		return jobs.JobError{
@@ -109,12 +76,12 @@ fn (mut p Processor) assign_job(mut client_ client.Client, guid string) ! {
 	}
 
 	// push guid to active queue
-	mut q_active := client_.redis.queue_get('jobs.processor.active')
+	mut q_active := p.client.redis.queue_get('jobs.processor.active')
 	q_active.add(guid)!
 
 	// push guid to queue of actor which will handle job
 	q_key := 'jobs.actors.${job.action.all_before_last('.')}'
-	mut q_actor := client_.redis.queue_get(q_key)
+	mut q_actor := p.client.redis.queue_get(q_key)
 	q_actor.add(guid)!
 
 	p.logger.debug('Assigned job ${guid} to ${q_key}:')
@@ -122,28 +89,28 @@ fn (mut p Processor) assign_job(mut client_ client.Client, guid string) ! {
 }
 
 // return_job returns a job by placing it to the correct redis return queue
-fn (mut p Processor) return_job(mut client_ client.Client, guid string) ! {
-	if client_.redis.hexists('rmb.db', guid)! {
-		p.return_job_rmb(mut client_, guid)!
+fn (mut p Processor) return_job(guid string) ! {
+	if p.client.redis.hexists('rmb.db', guid)! {
+		p.return_job_rmb(guid)!
 	} else {
-		mut q_return := client_.redis.queue_get('jobs.return.${guid}')
+		mut q_return := p.client.redis.queue_get('jobs.return.${guid}')
 		q_return.add(guid)!
 	}
 	p.logger.debug('Returned job ${guid}')
 }
 
 // handle_error places guid to jobs.return queue with an error
-fn (mut p Processor) handle_error(mut client_ client.Client, error IError) {
+fn (mut p Processor) handle_error(error IError) {
 	if error is jobs.JobError {
-		mut job := client_.job_get(error.job_guid) or {
+		mut job := p.client.job_get(error.job_guid) or {
 			eprintln('Failed getting the job with id ${error.job_guid}: ${err}')
 			return
 		}
-		client_.job_error_set(mut job, error.msg) or {
+		p.client.job_error_set(mut job, error.msg) or {
 			eprintln('Failed modifying the status of the job ${error.job_guid} to error: ${err}')
 			return
 		}
-		p.return_job(mut client_, error.job_guid) or {
+		p.return_job(error.job_guid) or {
 			eprintln('Failed returning the job ${error.job_guid}: ${err}')
 			return
 		}
@@ -153,19 +120,16 @@ fn (mut p Processor) handle_error(mut client_ client.Client, error IError) {
 }
 
 pub fn (mut p Processor) reset() ! {
-	mut client_ := client.new(p.redis_address) or {
-		return
-	}
-	client_.redis.flushall()!
-	client_.redis.disconnect()
-	client_.redis.socket_connect()!
+	p.client.redis.flushall()!
+	p.client.redis.disconnect()
+	p.client.redis.socket_connect()!
 }
 
 // todo: fix if needed
 // fn (mut p Processor) restart()! {
-// 	client_.redis.save()!
-// 	client_.redis.shutdown()!
+// 	p.client.redis.save()!
+// 	p.client.redis.shutdown()!
 // 	// os.execute('redis-server --daemonize yes &')
 // 	time.sleep(1000000)
-// 	client_.redis.socket_connect()!
+// 	p.client.redis.socket_connect()!
 // }

--- a/baobab/processor/processor.v
+++ b/baobab/processor/processor.v
@@ -2,8 +2,9 @@ module processor
 
 import freeflowuniverse.baobab.client
 import freeflowuniverse.baobab.jobs
+
 import log
-import time
+import rand
 
 [noinit]
 pub struct Processor {
@@ -26,41 +27,51 @@ pub fn new(redis_address string, logger &log.Logger) !Processor {
 // returns error and result responses from actor to caller of job
 pub fn (mut p Processor) run() {
 	p.logger.info('Processor is running')
-
-	mut q_rmb := p.client.redis.queue_get('msgbus.execute_job')
-	mut q_in := p.client.redis.queue_get('jobs.processor.in')
-	mut q_error := p.client.redis.queue_get('jobs.processor.error')
-	mut q_result := p.client.redis.queue_get('jobs.processor.result')
-
 	p.running = true
+	mut queues := ['msgbus.execute_job', 'jobs.processor.in', 'jobs.processor.error', 'jobs.processor.result']
 	for p.running {
-		// get guid from processor.in queue and assign job to actor
-		guid_in := q_in.pop() or { '' }
-		if guid_in != '' {
-			p.logger.debug('Received job ${guid_in}')
-			p.assign_job(guid_in) or { p.handle_error(err) }
+		rand.shuffle[string](mut queues) or {
+			p.logger.error("Failed to shuffle queues")
 		}
-
-		// get msg from rmb queue, parse job, assign to actor
-		if guid_rmb := p.get_rmb_job(mut q_rmb) {
-			p.logger.debug('Received job ${guid_rmb} from RMB')
-			p.assign_job(guid_rmb) or { p.handle_error(err) }
+		res := p.client.redis.brpop(queues, 1) or {
+			p.logger.error('Failed to brpop queues')
+			continue
 		}
-
-		// get guid from processor.error queue and move to return queue
-		guid_error := q_error.pop() or { '' }
-		if guid_error != '' {
-			p.logger.debug('Received error response for job: ${guid_error} ')
-			p.return_job(guid_error) or { p.handle_error(err) }
+		if res.len == 0 {
+			// no guids to handle
+			continue
+		}		
+		if res.len != 2 {
+			p.logger.error('Expected 2 items in result of brpop!')
+			continue
 		}
-
-		// get guid from processor.result queue and move to return queue
-		guid_result := q_result.pop() or { '' }
-		if guid_result != '' {
-			p.logger.debug('Received result for job: ${guid_result}')
-			p.return_job(guid_result) or { p.handle_error(err) }
+		match res[0] {
+			'msgbus.execute_job' {
+				if guid_rmb := p.get_rmb_job(res[1]) {
+					// get msg from rmb queue, parse job, assign to actor
+					p.logger.debug('Received job with guid ${guid_rmb} from RMB')
+					p.assign_job(guid_rmb) or { p.handle_error(err) }
+				}
+			}
+			'jobs.processor.in' {
+				// get guid from processor.in queue and assign job to actor
+				p.logger.debug('Received job with guid ${res[1]}')
+				p.assign_job(res[1]) or { p.handle_error(err) }
+			} 
+			'jobs.processor.error' {
+				// get guid from processor.error queue and move to return queue
+				p.logger.debug('Received error response for job with guid ${res[1]} ')
+				p.return_job(res[1]) or { p.handle_error(err) }
+			}
+			'jobs.processor.result' {
+				// get guid from processor.result queue and move to return queue
+				p.logger.debug('Received result for job with guid ${res[1]}')
+				p.return_job(res[1]) or { p.handle_error(err) }
+			}
+			else {
+				p.logger.error("Unknown queue ${res[0]}")
+			}
 		}
-		time.sleep(100 * time.millisecond)
 	}
 }
 

--- a/baobab/processor/processor.v
+++ b/baobab/processor/processor.v
@@ -34,15 +34,9 @@ pub fn (mut p Processor) run() {
 			p.logger.error("Failed to shuffle queues")
 		}
 		res := p.client.redis.brpop(queues, 1) or {
-			p.logger.error('Failed to brpop queues')
-			continue
-		}
-		if res.len == 0 {
-			// no guids to handle
-			continue
-		}
-		if res.len != 2 {
-			p.logger.error('Expected 2 items in result of brpop!')
+			if "$err" != "timeout on brpop" {
+				p.logger.error('Failed to brpop queues')
+			}
 			continue
 		}
 		if res[1] == "" {

--- a/baobab/processor/processor.v
+++ b/baobab/processor/processor.v
@@ -39,7 +39,7 @@ pub fn (mut p Processor) run() {
 			}
 			continue
 		}
-		if res[1] == "" {
+		if res.len != 2 || res[1] == "" {
 			continue
 		}
 		match res[0] {

--- a/baobab/processor/processor_test.v
+++ b/baobab/processor/processor_test.v
@@ -142,9 +142,8 @@ fn test_run() {
 	// timeout on 1 minute
 	now := time.now()
 	for time.since(now) < time.minute {
-		if redis.llen('jobs.processor.in')! == 0 && 
-			redis.llen('jobs.processor.error')! == 0 && 
-			redis.llen('jobs.processor.result')! == 0 {
+		if redis.llen('jobs.processor.in')! == 0 && redis.llen('jobs.processor.error')! == 0
+			&& redis.llen('jobs.processor.result')! == 0 {
 			break
 		}
 	}

--- a/baobab/processor/processor_test.v
+++ b/baobab/processor/processor_test.v
@@ -130,16 +130,24 @@ fn test_run() {
 		q_in.add(case.job.guid)!
 	}
 
-	time.sleep(500000) // wait processor work
-
 	// feed processor.error/result queue with test jobs, mocking actor
 	mut q_result := redis.queue_get('jobs.processor.result')
 	for case in test_cases {
-		guid := redis.rpop(case.actor_queue)!
-		q_result.add(guid)!
+		// processor should put the job in the actor queue, fail if timeout exceeds
+		res := redis.brpop([case.actor_queue], 60)!
+		assert res.len == 2
+		q_result.add(res[1])!
 	}
 
-	time.sleep(500000) // wait processor work
+	// timeout on 1 minute
+	now := time.now()
+	for time.since(now) < time.minute {
+		if redis.llen('jobs.processor.in')! == 0 && 
+			redis.llen('jobs.processor.error')! == 0 && 
+			redis.llen('jobs.processor.result')! == 0 {
+			break
+		}
+	}
 
 	// assert all jobs.processor queues are empty
 	assert redis.llen('jobs.processor.in')! == 0

--- a/baobab/processor/processor_test.v
+++ b/baobab/processor/processor_test.v
@@ -130,17 +130,16 @@ fn test_run() {
 		q_in.add(case.job.guid)!
 	}
 
-	time.sleep(500000000) // wait processor work
+	time.sleep(500000) // wait processor work
 
 	// feed processor.error/result queue with test jobs, mocking actor
-	mut q_error := redis.queue_get('jobs.processor.error')
 	mut q_result := redis.queue_get('jobs.processor.result')
 	for case in test_cases {
 		guid := redis.rpop(case.actor_queue)!
 		q_result.add(guid)!
 	}
 
-	time.sleep(500000000) // wait processor work
+	time.sleep(500000) // wait processor work
 
 	// assert all jobs.processor queues are empty
 	assert redis.llen('jobs.processor.in')! == 0

--- a/baobab/processor/rmb.v
+++ b/baobab/processor/rmb.v
@@ -1,7 +1,6 @@
 module processor
 
 import freeflowuniverse.baobab.jobs
-
 import encoding.base64
 import json
 import time

--- a/baobab/processor/rmb.v
+++ b/baobab/processor/rmb.v
@@ -1,6 +1,5 @@
 module processor
 
-import freeflowuniverse.baobab.client
 import freeflowuniverse.baobab.jobs
 import freeflowuniverse.crystallib.redisclient
 import encoding.base64
@@ -66,9 +65,9 @@ pub mut:
 
 // listens to rmb queue for incoming execute job messages
 // parses message into job saves job and message, returns optional guid
-fn (mut p Processor) get_rmb_job(mut client_ client.Client) ?string {
+fn (mut p Processor) get_rmb_job(mut q_rmb redisclient.RedisQueue) ?string {
 	// incoming jobs from rmb peer
-	encoded_msg := client_.redis.brpop('msgbus.execute_job', 1) or { '' }
+	encoded_msg := q_rmb.pop() or { '' }
 
 	if encoded_msg != '' {
 		msg := json.decode(RMBMessage, encoded_msg) or {
@@ -78,24 +77,24 @@ fn (mut p Processor) get_rmb_job(mut client_ client.Client) ?string {
 		decoded_job := base64.decode_str(msg.dat)
 		job := jobs.json_load(decoded_job) or {
 			p.logger.error('Failed decoding ${decoded_job} to Job: ${err}')
-			p.send_rmb_error_message(mut client_, .failed_decoding_payload_to_job, msg)
+			p.send_rmb_error_message(.failed_decoding_payload_to_job, msg)
 			return none
 		}
 		if job.src_twinid != msg.src.u32() {
 			p.logger.error('Job is either not meant for us or the sender is not who they claim to be: ${encoded_msg}')
-			p.send_rmb_error_message(mut client_, .unauthorized, msg)
+			p.send_rmb_error_message(.unauthorized, msg)
 			return none
 		}
 		// save job
-		client_.job_set(job) or {
+		p.client.job_set(job) or {
 			p.logger.error('Failed setting ${job}: ${err}')
-			p.send_rmb_error_message(mut client_, .internal_error, msg)
+			p.send_rmb_error_message(.internal_error, msg)
 			return none
 		}
 		// save message
-		client_.redis.hset('rmb.db', '${job.guid}', encoded_msg) or {
+		p.client.redis.hset('rmb.db', '${job.guid}', encoded_msg) or {
 			p.logger.error('Failed setting ${job.guid} in hset rmb.db: ${err}')
-			p.send_rmb_error_message(mut client_, .internal_error, msg)
+			p.send_rmb_error_message(.internal_error, msg)
 			return none
 		}
 		return job.guid
@@ -103,8 +102,8 @@ fn (mut p Processor) get_rmb_job(mut client_ client.Client) ?string {
 	return none
 }
 
-fn (mut p Processor) send_rmb_error_message(mut client_ client.Client, code RMBErrorCode, msg &RMBMessage) {
-	mut q_return := client_.redis.queue_get(msg.ret)
+fn (mut p Processor) send_rmb_error_message(code RMBErrorCode, msg &RMBMessage) {
+	mut q_return := p.client.redis.queue_get(msg.ret)
 	response := RMBError{
 		dst: msg.src
 		ref: msg.ref
@@ -121,13 +120,13 @@ fn (mut p Processor) send_rmb_error_message(mut client_ client.Client, code RMBE
 }
 
 // return_job returns a job by placing it to the correct redis return queue
-fn (mut p Processor) return_job_rmb(mut client_ client.Client, guid string) ! {
-	job := client_.job_get(guid)!
+fn (mut p Processor) return_job_rmb(guid string) ! {
+	job := p.client.job_get(guid)!
 
 	// get message from rmb.db, set data to returned job
-	mut encoded_msg := client_.redis.hget('rmb.db', guid)!
+	mut encoded_msg := p.client.redis.hget('rmb.db', guid)!
 	mut msg := json.decode(RMBMessage, encoded_msg)!
-	mut q_return := client_.redis.queue_get(msg.ret)
+	mut q_return := p.client.redis.queue_get(msg.ret)
 	response := RMBResponse{
 		dst: msg.src
 		dat: base64.encode_str(job.json_dump())

--- a/baobab/processor/rmb_test.v
+++ b/baobab/processor/rmb_test.v
@@ -58,11 +58,9 @@ fn generate_test_cases() ![]RMBTestCase {
 fn test_get_rmb_job() ! {
 	mut p := new('localhost:6379', get_logger('test_get_rmb_job'))!
 	cases := generate_test_cases()!
-	mut q_rmb := p.client.redis.queue_get('msgbus.execute_job')
 	for case in cases {
 		encoded := json.encode(case.rmb_msg)
-		q_rmb.add(encoded)!
-		job_guid := p.get_rmb_job(mut q_rmb) or { '' }
+		job_guid := p.get_rmb_job(encoded) or { '' }
 		assert job_guid == case.job.guid
 		assert p.client.redis.hexists('jobs.db', job_guid)!
 	}


### PR DESCRIPTION
This completes #13:
- We use brpop instead of rpop so that we block until there is a new job => reduces cpu usage in case there is nothing to do
- Improved tests 