### PR TITLE
21 allow rmb jobs with source twin with format idsession 

### DIFF
--- a/baobab/processor/rmb.v
+++ b/baobab/processor/rmb.v
@@ -12,6 +12,9 @@ pub fn error_code_to_message(code RMBErrorCode) string {
 		.failed_decoding_payload_to_job {
 			return 'Failed to decode the received payload to job. It should contain the base64 encoded representation of a json job.'
 		}
+		.failed_decoding_source_twin {
+			return 'Faild to decode the source twin id from the message.'
+		}
 		.unauthorized {
 			return 'Unauthorized to execute the job. Make sure that the source and desition twin ids of the rmb message match the ones from the job.'
 		}
@@ -81,7 +84,13 @@ fn (mut p Processor) get_rmb_job(encoded_msg string) ?string {
 		p.send_rmb_error_message(.failed_decoding_payload_to_job, msg)
 		return none
 	}
-	if job.src_twinid != msg.src.u32() {
+	twin_source := msg.src.split(':')
+	if twin_source.len == 0 {
+		p.logger.error('Failed decoding source twin from job ${decoded_job}')
+		p.send_rmb_error_message(.failed_decoding_source_twin, msg)
+		return none
+	}
+	if job.src_twinid != twin_source[0].u32() {
 		p.logger.error('Job is either not meant for us or the sender is not who they claim to be: ${encoded_msg}')
 		p.send_rmb_error_message(.unauthorized, msg)
 		return none

--- a/baobab/processor/rmb.v
+++ b/baobab/processor/rmb.v
@@ -12,8 +12,8 @@ pub fn error_code_to_message(code RMBErrorCode) string {
 		.failed_decoding_payload_to_job {
 			return 'Failed to decode the received payload to job. It should contain the base64 encoded representation of a json job.'
 		}
-		.failed_decoding_source_twin {
-			return 'Faild to decode the source twin id from the message.'
+		.empty_source_twin_id {
+			return 'The source twin id is empty in the RMB message.'
 		}
 		.unauthorized {
 			return 'Unauthorized to execute the job. Make sure that the source and desition twin ids of the rmb message match the ones from the job.'
@@ -86,8 +86,8 @@ fn (mut p Processor) get_rmb_job(encoded_msg string) ?string {
 	}
 	twin_source := msg.src.split(':')
 	if twin_source.len == 0 {
-		p.logger.error('Failed decoding source twin from job ${decoded_job}')
-		p.send_rmb_error_message(.failed_decoding_source_twin, msg)
+		p.logger.error('The source twin id is empty in ${decoded_job}')
+		p.send_rmb_error_message(.empty_source_twin_id, msg)
 		return none
 	}
 	if job.src_twinid != twin_source[0].u32() {

--- a/baobab/processor/rmb.v
+++ b/baobab/processor/rmb.v
@@ -28,6 +28,7 @@ pub fn error_code_to_message(code RMBErrorCode) string {
 // when handeling RMB messages.
 pub enum RMBErrorCode as u8 {
 	failed_decoding_payload_to_job
+	empty_source_twin_id
 	unauthorized
 	internal_error
 }


### PR DESCRIPTION
Fixed the issue:
- We split the source twin id on colon and check the first part only